### PR TITLE
Spelling correction

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "url": "https://blogotext.org/",
     "license": "MIT",
     "maintainer": {
-        "name": "antoine",
+        "name": "Antoine",
         "email": "antoine@miaou.org",
         "url": "https://miaou.org"
     },


### PR DESCRIPTION
To cleanup Active maintainers list on https://dash.yunohost.org/app_maintainer_dash

Two others maintainers apps use "Antoine"

[List of maintainer apps](https://dash.yunohost.org/app_maintainer_dash/antoine)

Other Apps manifest: 

- https://github.com/YunoHost-Apps/mediawiki_ynh/blob/8f1c238f2e134c4be795186dddc8a306e57e88f7/manifest.json#L12-L16
- https://github.com/YunoHost-Apps/pluxml_ynh/blob/7797d99486bc9c57a4e53f57ec1cd40c37205a9a/manifest.json#L12-L16